### PR TITLE
fix: Python client is currently leaking resources since the aiohttp client isn't closed

### DIFF
--- a/tecton_client/responses.py
+++ b/tecton_client/responses.py
@@ -102,6 +102,9 @@ class FeatureStatus(str, Enum):
     """The feature values were not found in the online store either because the join keys do not exist
     or the feature values are outside ttl."""
 
+    CACHED = "CACHED"
+    """The feature values were cached in the backend and retrieved from the cache."""
+
     UNKNOWN = "UNKNOWN"
     """An unknown status code occurred, most likely because an error occurred during feature retrieval."""
 

--- a/tecton_client/tecton_client.py
+++ b/tecton_client/tecton_client.py
@@ -270,3 +270,6 @@ class TectonClient:
 
         """
         asyncio_run(self._tecton_http_client.close())
+
+    def __del__(self):
+        self.close()

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -102,7 +102,7 @@ class TestResponse:
                     (FloatType, FeatureStatus.MISSING_DATA, "2023-05-03T00:00:00"),
                     (IntType, FeatureStatus.PRESENT, "2023-05-03T00:00:00"),
                     (FloatType, FeatureStatus.PRESENT, "2023-05-03T00:00:00"),
-                    (ArrayType, FeatureStatus.PRESENT, "2023-05-03T00:00:00"),
+                    (ArrayType, FeatureStatus.CACHED, "2023-05-03T00:00:00"),
                 ],
             )
         ],

--- a/tests/tecton_client_test.py
+++ b/tests/tecton_client_test.py
@@ -98,7 +98,7 @@ class TestTectonClient:
         (FloatType, FeatureStatus.MISSING_DATA, "2023-05-03T00:00:00"),
         (IntType, FeatureStatus.PRESENT, "2023-05-03T00:00:00"),
         (FloatType, FeatureStatus.PRESENT, "2023-05-03T00:00:00"),
-        (ArrayType, FeatureStatus.PRESENT, "2023-05-03T00:00:00"),
+        (ArrayType, FeatureStatus.CACHED, "2023-05-03T00:00:00"),
     ]
     expected_slo_info = {
         "dynamodb_response_size_bytes": None,

--- a/tests/test_data/single/sample_response_metadata.json
+++ b/tests/test_data/single/sample_response_metadata.json
@@ -55,7 +55,7 @@
             "type": "string"
           }
         },
-        "status": "PRESENT"
+        "status": "CACHED"
       }
     ],
     "sloInfo": {


### PR DESCRIPTION
## Summary (What and Why)

Seeing this error when using python client
```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10593c3a0>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x1059589a0>, 0.358368791)]']
connector: <aiohttp.connector.TCPConnector object at 0x1049475b0>
```

Fixed the issue. 

## Test Plan

<!--
How have you tested (or planning to test) this change?
-->

## Release Plan

<!--
How are you planning to release this change? Details can include snapshots, release versions, etc.
-->

## GitHub Issue:

https://github.com/tecton-ai/tecton-http-client-python/issues/XXX
