### PR TITLE
fix: http request keeps the response order

### DIFF
--- a/tecton_client/http_client.py
+++ b/tecton_client/http_client.py
@@ -178,31 +178,28 @@ class TectonHttpClient:
 
         # Execute the tasks in parallel and wait for them to complete or timeout
         start_time = time.time()
-        task_results = await asyncio.gather([asyncio.wait_for(task, timeout.total_seconds() if timeout else timeout) for task in tasks], return_exceptions=True)
+        done, pending = await asyncio.wait(tasks, timeout=timeout.total_seconds() if timeout else timeout)
         end_time = time.time()
 
         # Calculate the latency of the request
         latency = timedelta(seconds=(end_time - start_time))
 
-        # Capture results of the tasks:-
-        # If the task is in the done list, it either completes successfully or returns an exception from the server.
-        # If the task is successful, i.e. without an exception, return the result.
-        # Else, store None in case the task returned an exception or timed out.
-        results = [res if not isinstance(res, Exception) else None for res in task_results]
-
         # Get the list of exceptions thrown by the HTTP client
         thrown_exceptions = None
-        for res in task_results:
-            if isinstance(res, Exception):
-                thrown_exceptions = res
-                break
+        # Capture results of the tasks:-
+        # If the task is successful, i.e. without an exception, return the result.
+        # Else, store None in case the task returned an exception or timed out.
+        results = [task.result() if task in done and not task.exception() else None for task in tasks]
+
+        # Get the list of exceptions thrown by the HTTP client
+        thrown_exceptions = [task.exception() for task in done if task.exception()]
 
         # Close all the created tasks
         await self._close_tasks(tasks=pending)
 
         # If there are any exceptions thrown by the HTTP client, raise the first exception
         if thrown_exceptions:
-            raise thrown_exceptions
+            raise thrown_exceptions[0]
 
         return results, latency
 

--- a/tecton_client/http_client.py
+++ b/tecton_client/http_client.py
@@ -184,9 +184,8 @@ class TectonHttpClient:
         # Calculate the latency of the request
         latency = timedelta(seconds=(end_time - start_time))
 
-        # Get the list of exceptions thrown by the HTTP client
-        thrown_exceptions = None
         # Capture results of the tasks:-
+        # If the task is in the done list, it either completes successfully or returns an exception from the server.
         # If the task is successful, i.e. without an exception, return the result.
         # Else, store None in case the task returned an exception or timed out.
         results = [task.result() if task in done and not task.exception() else None for task in tasks]

--- a/tecton_client/http_client.py
+++ b/tecton_client/http_client.py
@@ -178,9 +178,7 @@ class TectonHttpClient:
 
         # Execute the tasks in parallel and wait for them to complete or timeout
         start_time = time.time()
-
-        task_results = await asyncio.gather(*tasks,timeout=timeout, return_exceptions=True)
-
+        task_results = await asyncio.gather([asyncio.wait_for(task, timeout.total_seconds() if timeout else timeout) for task in tasks], return_exceptions=True)
         end_time = time.time()
 
         # Calculate the latency of the request

--- a/tecton_client/responses.py
+++ b/tecton_client/responses.py
@@ -449,7 +449,7 @@ class GetFeaturesBatchResponse:
         # For each micro-batch response, get each response object from the list of responses if it exists
         for micro_batch_response in micro_batch_response_list:
             if micro_batch_response:
-                self.batch_response_list+=micro_batch_response.response_list
+                self.batch_response_list += micro_batch_response.response_list
             else:
                 self.batch_response_list.append(None)
 

--- a/tecton_client/responses.py
+++ b/tecton_client/responses.py
@@ -445,16 +445,13 @@ class GetFeaturesBatchResponse:
             else response
             for response in responses_list
         ]
-
+        self.batch_response_list = []
         # For each micro-batch response, get each response object from the list of responses if it exists
-        self.batch_response_list = [
-            response
-            for micro_batch_response in micro_batch_response_list
-            if micro_batch_response
-            for response in micro_batch_response.response_list
-        ]
-        # If the micro-batch response is None (i.e. the request timed out), add None to the batch response list
-        self.batch_response_list += [None] * micro_batch_response_list.count(None) * micro_batch_size
+        for micro_batch_response in micro_batch_response_list:
+            if micro_batch_response:
+                self.batch_response_list+=micro_batch_response.response_list
+            else:
+                self.batch_response_list.append(None)
 
         batch_slo_info_list = [
             response.batch_slo_info for response in micro_batch_response_list if response and response.batch_slo_info

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -226,7 +226,7 @@ class TestHttpClient:
             url=self.full_url,
             callback=conditional_callback,
             repeat=True,
-        )                
+        )
 
         requests_list = []
         for i in range(number_of_requests):

--- a/tests/responses_test.py
+++ b/tests/responses_test.py
@@ -168,6 +168,21 @@ class TestResponse:
         for response, expected_answer in zip(batch_response.batch_response_list, expected_answers_list):
             self.assert_answers(expected_answer, response)
 
+    def test_batch_responses_with_timeout_micro_batch_1(self) -> None:
+        http_responses_list = [
+            HTTPResponse(result={'result': {'features': [True]}, 'metadata': {'features': [{'name': 'transaction_amount_is_high.transaction_amount_is_high', 'dataType': {'type': 'boolean'}}]}}, latency=timedelta(milliseconds=10)),
+            None,
+            HTTPResponse(result={'result': {'features': [True]}, 'metadata': {'features': [{'name': 'transaction_amount_is_high.transaction_amount_is_high', 'dataType': {'type': 'boolean'}}]}}, latency=timedelta(milliseconds=10)),
+            None,
+        ]
+        batch_response = GetFeaturesBatchResponse(
+            responses_list=http_responses_list, request_latency=timedelta(milliseconds=10), micro_batch_size=1
+        )
+        assert batch_response.batch_slo_info is None
+        assert batch_response.request_latency == timedelta(milliseconds=10)
+        for i in range(2):
+            assert batch_response.batch_response_list[2*i + 1] is None
+
     @pytest.mark.parametrize(
         "file_names_list, micro_batch_size, number_of_responses, feature_vector_len, feature_name, order_of_responses",
         [


### PR DESCRIPTION
## Summary (What and Why)

<!--
Short summary of your change and why are you making it (at least 1-2 sentences). Include any additional notes that would be helpful for reviewers if necessary.
-->

asyncio.wait can be out of order if one request timeout. change to asyncio.gather to keep the order of request

## Test Plan

<!--
How have you tested (or planning to test) this change?
-->

Implemented unittest

## Release Plan

<!--
How are you planning to release this change? Details can include snapshots, release versions, etc.
-->

## GitHub Issue:

https://github.com/tecton-ai/tecton-http-client-python/issues/XXX
