### PR TITLE
Support pytest being as low as 6.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest~=7.3.1
+pytest>=6.2.5,<7.4.0
 aiohttp~=3.8.4
 aioresponses~=0.7.4
 nest-asyncio~=1.5.6


### PR DESCRIPTION
## Summary (What and Why)

Pytest is being fixed at 7.3.*, however this pytest version has some breaking changes with our codebase that uses 6.2.5. It appears this requirement is not essential, and everything runs fine with pytest 6.2.5.

The current requirement is pytest~=7.3.1, which supports all build versions of 7.3. I modified the requirements to still support any of 7.3.*, but also allow lower versions (as low as 6.2.5 here).

## Test Plan

Ran pytests with 6.2.5, everything still passes

## Release Plan

Given there's no functional change, I believe this can just be released as a new build version of the library, if Tecton is comfortable with that

