### PR TITLE
Differentiate core package and dev requirements

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,17 +25,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v3
-      id: cache
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.*') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -e '.[dev]'
     - name: Test with pytest
       run: |
         python -m pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,14 +46,20 @@ name = "tecton-client"
 description = "A Python Client for the Tecton FeatureService API"
 requires-python = ">=3.8"
 license = "Apache-2.0"
-dynamic = ["version", "dependencies"]
+dynamic = ["version"]
 readme = "README.md"
+dependencies = [
+  "aiohttp~=3.8.4",
+  "aioresponses~=0.7.4",
+  "nest-asyncio~=1.5.6",
+  "pytest-asyncio~=0.15.1",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=6.2.5,<7.4.0"]
 
 [tool.hatch.version]
 path = "tecton_client/__about__.py"
-
-[tool.hatch.metadata.hooks.requirements_txt]
-files = ["requirements.txt"]
 
 [project.urls]
 "Source" = "https://github.com/tecton-ai/tecton-http-client-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,15 @@ dynamic = ["version"]
 readme = "README.md"
 dependencies = [
   "aiohttp~=3.8.4",
-  "aioresponses~=0.7.4",
   "nest-asyncio~=1.5.6",
-  "pytest-asyncio~=0.15.1",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=6.2.5,<7.4.0"]
+dev = [
+  "aioresponses~=0.7.4",
+  "pytest>=6.2.5,<7.4.0",
+  "pytest-asyncio~=0.15.1",
+]
 
 [tool.hatch.version]
 path = "tecton_client/__about__.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-pytest>=6.2.5,<7.4.0
-aiohttp~=3.8.4
-aioresponses~=0.7.4
-nest-asyncio~=1.5.6
-pytest-asyncio~=0.15.1


### PR DESCRIPTION
## Summary (What and Why)

Pytest, aioresponses, and pytest-asyncio are not a requirement of the package, so we should move it to the dev requirements. This will ensure no dependency conflicts with `pytest` will affect installers

This change adjusts for this failure by specifying the requirements directly in the pyproject.toml. It specifies an optional set of `dev` requirements, just `pytest` for now.

## Test Plan

PR tests

## Release Plan

Owned by online store team