### PR TITLE
Handle Case where API Doesn't return inputJoinKeys / inputRequestContextKeys

### DIFF
--- a/tecton_client/_internal/async_tecton_client.py
+++ b/tecton_client/_internal/async_tecton_client.py
@@ -83,7 +83,7 @@ class AsyncTectonClient:
     async def get_features(
         self,
         *,
-        feature_service_name: Optional[str] = None,
+        feature_service_name: str,
         join_key_map: Optional[Dict[str, Union[int, str, type(None)]]] = None,
         request_context_map: Optional[Dict[str, Any]] = None,
         metadata_options: Optional[MetadataOptions] = None,
@@ -131,7 +131,7 @@ class AsyncTectonClient:
     async def get_feature_service_metadata(
         self,
         *,
-        feature_service_name: Optional[str] = None,
+        feature_service_name: str,
         workspace_name: Optional[str] = None,
     ) -> GetFeatureServiceMetadataResponse:
         """Get metadata about a Feature Service.

--- a/tecton_client/_internal/data_types.py
+++ b/tecton_client/_internal/data_types.py
@@ -93,16 +93,16 @@ class GetFeatureServiceMetadataResponse:
 
     """
 
-    input_join_keys: List[dict]
-    input_request_context_keys: List[dict]
+    input_join_keys: Optional[List[dict]]
+    input_request_context_keys: Optional[List[dict]]
     feature_values: List[dict]
 
     @classmethod
     def from_response(cls, resp: dict):
-        """Constructor to create a GetFeatureServiceMetadataResponse from the json resonse of api"""
+        """Constructor to create a GetFeatureServiceMetadataResponse from the json response of api"""
         return GetFeatureServiceMetadataResponse(
-            input_join_keys=resp["inputJoinKeys"],
-            input_request_context_keys=resp["inputRequestContextKeys"],
+            input_join_keys=resp.get("inputJoinKeys"),
+            input_request_context_keys=resp.get("inputRequestContextKeys"),
             feature_values=resp["featureValues"],
         )
 

--- a/tecton_client/_internal/tecton_client.py
+++ b/tecton_client/_internal/tecton_client.py
@@ -75,7 +75,7 @@ class TectonClient:
     def get_features(
         self,
         *,
-        feature_service_name: Optional[str] = None,
+        feature_service_name: str,
         join_key_map: Optional[Dict[str, Union[int, str, type(None)]]] = None,
         request_context_map: Optional[Dict[str, Any]] = None,
         metadata_options: Optional[MetadataOptions] = None,
@@ -123,7 +123,7 @@ class TectonClient:
     def get_feature_service_metadata(
         self,
         *,
-        feature_service_name: Optional[str] = None,
+        feature_service_name: str,
         workspace_name: Optional[str] = None,
     ) -> GetFeatureServiceMetadataResponse:
         """Get metadata about a Feature Service.


### PR DESCRIPTION
The return structure of the api is variable; instead of returning empty lists it omits `inputJoinKeys `/ `inputRequestContextKeys` from the response if not applicable. Handling this case.