### PR TITLE
Fix async "'AsyncClient.post' was never awaited" error in get AsyncTectonClient.get_feature_service_metadata

### DIFF
--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -1,10 +1,11 @@
 import asyncio
+import os
 
 from tecton_client import AsyncTectonClient, MetadataOptions
 
 my_url = "https://explore.tecton.ai/"
 workspace = "prod"
-my_api_key = "ada955cefef2e6e003c9a7477d514d4d"
+my_api_key = os.environ.get("TECTON_API_KEY")
 
 async_client = AsyncTectonClient(url=my_url, api_key=my_api_key, default_workspace_name=workspace)
 

--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -1,12 +1,10 @@
 import asyncio
-import os
 
 from tecton_client import AsyncTectonClient, MetadataOptions
 
 my_url = "https://explore.tecton.ai/"
 workspace = "prod"
-my_api_key = os.environ.get("TECTON_API_KEY")
-
+my_api_key = "ada955cefef2e6e003c9a7477d514d4d"
 
 async_client = AsyncTectonClient(url=my_url, api_key=my_api_key, default_workspace_name=workspace)
 
@@ -24,6 +22,17 @@ async def call_api_ten_times():
     responses = await asyncio.gather(*requests)
     for resp in responses:
         print(resp.result.features)
+
+    # also call get_feature_service_metadata
+    requests = [
+        async_client.get_feature_service_metadata(
+            feature_service_name="fraud_detection_feature_service:v2",
+        )
+        for i in range(10)
+    ]
+    responses = await asyncio.gather(*requests)
+    for resp in responses:
+        print(resp)
 
 
 asyncio.run(call_api_ten_times())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ readme = "README.md"
 [project.optional-dependencies]
 dev = [
   "pytest>=6.2.5",
-  "pytest_httpx"
+  "pytest_httpx",
+  "pytest-asyncio"
 ]
 docs = [
   "alabaster==0.7.16",

--- a/tecton_client/_internal/async_tecton_client.py
+++ b/tecton_client/_internal/async_tecton_client.py
@@ -147,7 +147,7 @@ class AsyncTectonClient:
             feature_service_name=feature_service_name,
             workspace_name=workspace_name,
         )
-        resp = self._client.post(url=self._paths["get_feature_service_metadata"], json=request_data)
+        resp = await self._client.post(url=self._paths["get_feature_service_metadata"], json=request_data)
         try:
             resp.raise_for_status()
         except HTTPStatusError as exc:

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,16 +1,15 @@
 import json
-from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 from httpx import Headers
-from pytest import mark
 
 from tecton_client import AsyncTectonClient, MetadataOptions, RequestOptions
 from tecton_client.exceptions import NotFoundError
 
 
-class TestTectonClient(TestCase):
+class TestTectonClient(IsolatedAsyncioTestCase):
     def mockPatch(self, *args, **kwargs):
         patcher = patch(*args, **kwargs)
         self.addCleanup(patcher.stop)
@@ -45,12 +44,11 @@ class TestTectonClient(TestCase):
             url="https://fake.tecton.ai", api_key="fake-api-key", default_workspace_name="workspace", client=mock_client
         )
         mock_httpx_constructor.assert_not_called()
-        self.assertEquals(
+        self.assertEqual(
             mock_client.headers,
             {"authorization": "Tecton-key fake-api-key", "user-agent": "tecton-http-python-client 0.1.0test"},
         )
 
-    @mark.asyncio
     async def test_default_workspace_null(self):
         client = AsyncTectonClient(url="https://fake.tecton.ai", api_key="fake-api-key", client=self.mock_client)
 
@@ -63,9 +61,8 @@ class TestTectonClient(TestCase):
             workspace_name="override-workspace",
         )
         workspace = self.mock_client._request_log[0]["params"]["workspaceName"]
-        self.assertEquals(workspace, "override-workspace")
+        self.assertEqual(workspace, "override-workspace")
 
-    @mark.asyncio
     async def test_default_workspace(self):
         client = AsyncTectonClient(
             url="https://fake.tecton.ai",
@@ -76,9 +73,8 @@ class TestTectonClient(TestCase):
 
         await client.get_features(feature_service_name="fake-feature-service", join_key_map={"user_id": "id123"})
         workspace = self.mock_client._request_log[0]["params"]["workspaceName"]
-        self.assertEquals(workspace, "fake-workspace")
+        self.assertEqual(workspace, "fake-workspace")
 
-    @mark.asyncio
     async def test_override_workspace(self):
         client = AsyncTectonClient(
             url="https://fake.tecton.ai",
@@ -94,13 +90,14 @@ class TestTectonClient(TestCase):
         )
 
         workspace = self.mock_client._request_log[0]["params"]["workspaceName"]
-        self.assertEquals(workspace, "override-workspace")
+        self.assertEqual(workspace, "override-workspace")
 
-    @mark.asyncio
     async def test_get_features_encode(self):
         # using just magic_mock here in order to assert on client.post.assert_called_with
-        mock_http_client = MagicMock()
-        mock_http_client.post.return_value.json.return_value = {"result": {"features": []}}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": {"features": []}}
+        mock_http_client = AsyncMock()
+        mock_http_client.post.return_value = mock_response
         client = AsyncTectonClient(
             url="https://fake.tecton.ai",
             api_key="fake-api-key",
@@ -114,12 +111,11 @@ class TestTectonClient(TestCase):
             request_options=RequestOptions(read_from_cache=False),
         )
         mock_http_client.post.assert_called_with(
-            "https://fake.tecton.ai/api/v1/feature-service/get-features",
+            url="https://fake.tecton.ai/api/v1/feature-service/get-features",
             json={
                 "params": {
                     "workspaceName": "workspace",
                     "featureServiceName": "fake-feature-service",
-                    "featureServiceId": None,
                     "joinKeyMap": {"user_id": "id123"},
                     "requestContextMap": {},
                     "allowPartialResults": False,
@@ -135,15 +131,16 @@ class TestTectonClient(TestCase):
             },
         )
 
-    @mark.asycnio
     async def test_get_feature_service_metadata_encode(self):
         # using just magic_mock here in order to assert on client.post.assert_called_with
-        mock_http_client = MagicMock()
-        mock_http_client.post.return_value.json.return_value = {
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
             "inputJoinKeys": [],
             "inputRequestContextKeys": [],
             "featureValues": [],
         }
+        mock_http_client = AsyncMock()
+        mock_http_client.post.return_value = mock_response
         client = AsyncTectonClient(
             url="https://fake.tecton.ai",
             api_key="fake-api-key",
@@ -163,20 +160,28 @@ class TestTectonClient(TestCase):
             },
         )
 
-    @mark.asyncio
     async def test_get_features_decode(self):
-        test_client = httpx.Client(
+        test_client = httpx.AsyncClient(
             transport=httpx.MockTransport(lambda request: httpx.Response(200, json={"result": {"features": []}}))
         )
         client = AsyncTectonClient(
             url="https://fake.tecton.ai", api_key="fake-api-key", default_workspace_name="workspace", client=test_client
         )
         resp = await client.get_features(feature_service_name="fake-feature-service", join_key_map={"user_id": "id123"})
-        self.assertEquals(resp.result.features, [])
+        self.assertEqual(resp.result.features, [])
 
-    @mark.asyncio
+    async def test_get_feature_service_metadata_decode(self):
+        test_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(200, json={"featureValues": ["this"]}))
+        )
+        client = AsyncTectonClient(
+            url="https://fake.tecton.ai", api_key="fake-api-key", default_workspace_name="workspace", client=test_client
+        )
+        resp = await client.get_feature_service_metadata(feature_service_name="fake-feature-service")
+        self.assertEqual(resp.feature_values, ["this"])
+
     async def test_raise_error(self):
-        test_client = httpx.Client(
+        test_client = httpx.AsyncClient(
             transport=httpx.MockTransport(lambda request: httpx.Response(404, json={"result": {"features": []}}))
         )
         client = AsyncTectonClient(

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -14,7 +14,7 @@ class TestDataTypes(TestCase):
         with open(file_1) as f:
             resp = json.load(f)
         resp = GetFeaturesResponse.from_response(resp)
-        self.assertEquals(
+        self.assertEqual(
             resp.result.features,
             [["0"], None, [55.5, 57.88, 58.96, 57.66, None, 55.98], ["0", "1", None, "3", "4", None]],
         )
@@ -76,20 +76,20 @@ class TestDataTypes(TestCase):
         )
 
     def test_get_feature_value_simple_types(self):
-        self.assertEquals(GetFeaturesResponse._get_feature_value({"type": "string"}, "thing"), "thing")
-        self.assertEquals(GetFeaturesResponse._get_feature_value({"type": "string"}, "thing"), "thing")
-        self.assertEquals(GetFeaturesResponse._get_feature_value({"type": "int64"}, "1"), 1)
-        self.assertEquals(GetFeaturesResponse._get_feature_value({"type": "float64"}, 1), 1)
-        self.assertEquals(GetFeaturesResponse._get_feature_value({"type": "float64"}, "NaN"), "NaN")
+        self.assertEqual(GetFeaturesResponse._get_feature_value({"type": "string"}, "thing"), "thing")
+        self.assertEqual(GetFeaturesResponse._get_feature_value({"type": "string"}, "thing"), "thing")
+        self.assertEqual(GetFeaturesResponse._get_feature_value({"type": "int64"}, "1"), 1)
+        self.assertEqual(GetFeaturesResponse._get_feature_value({"type": "float64"}, 1), 1)
+        self.assertEqual(GetFeaturesResponse._get_feature_value({"type": "float64"}, "NaN"), "NaN")
 
     def test_get_feature_value_array(self):
-        self.assertEquals(
+        self.assertEqual(
             GetFeaturesResponse._get_feature_value({"type": "array", "elementType": {"type": "int64"}}, []), []
         )
-        self.assertEquals(
+        self.assertEqual(
             GetFeaturesResponse._get_feature_value({"type": "array", "elementType": {"type": "int64"}}, None), None
         )
-        self.assertEquals(
+        self.assertEqual(
             GetFeaturesResponse._get_feature_value(
                 {"type": "array", "elementType": {"type": "int64"}}, ["1", None, "2"]
             ),
@@ -97,7 +97,7 @@ class TestDataTypes(TestCase):
         )
 
     def test_get_feature_value_nested_array(self):
-        self.assertEquals(
+        self.assertEqual(
             GetFeaturesResponse._get_feature_value(
                 {"type": "array", "elementType": {"type": "array", "elementType": {"type": "int64"}}},
                 [["1", "2", None], None, []],
@@ -106,7 +106,7 @@ class TestDataTypes(TestCase):
         )
 
     def test_get_feature_value_map(self):
-        self.assertEquals(
+        self.assertEqual(
             GetFeaturesResponse._get_feature_value(
                 {
                     "type": "map",
@@ -119,7 +119,7 @@ class TestDataTypes(TestCase):
         )
 
     def test_get_feature_value_struct(self):
-        self.assertEquals(
+        self.assertEqual(
             GetFeaturesResponse._get_feature_value(
                 {
                     "type": "struct",

--- a/tests/test_tecton_client.py
+++ b/tests/test_tecton_client.py
@@ -44,7 +44,7 @@ class TestTectonClient(TestCase):
             url="https://fake.tecton.ai", api_key="fake-api-key", default_workspace_name="workspace", client=mock_client
         )
         mock_httpx_constructor.assert_not_called()
-        self.assertEquals(
+        self.assertEqual(
             mock_client.headers,
             {"authorization": "Tecton-key fake-api-key", "user-agent": "tecton-http-python-client 0.1.0test"},
         )
@@ -61,7 +61,7 @@ class TestTectonClient(TestCase):
             workspace_name="override-workspace",
         )
         workspace = self.mock_client._request_log[0]["params"]["workspaceName"]
-        self.assertEquals(workspace, "override-workspace")
+        self.assertEqual(workspace, "override-workspace")
 
     def test_default_workspace(self):
         client = TectonClient(
@@ -73,7 +73,7 @@ class TestTectonClient(TestCase):
 
         client.get_features(feature_service_name="fake-feature-service", join_key_map={"user_id": "id123"})
         workspace = self.mock_client._request_log[0]["params"]["workspaceName"]
-        self.assertEquals(workspace, "fake-workspace")
+        self.assertEqual(workspace, "fake-workspace")
 
     def test_override_workspace(self):
         client = TectonClient(
@@ -90,7 +90,7 @@ class TestTectonClient(TestCase):
         )
 
         workspace = self.mock_client._request_log[0]["params"]["workspaceName"]
-        self.assertEquals(workspace, "override-workspace")
+        self.assertEqual(workspace, "override-workspace")
 
     def test_get_features_encode(self):
         # using just magic_mock here in order to assert on client.post.assert_called_with
@@ -164,7 +164,7 @@ class TestTectonClient(TestCase):
             url="https://fake.tecton.ai", api_key="fake-api-key", default_workspace_name="workspace", client=test_client
         )
         resp = client.get_features(feature_service_name="fake-feature-service", join_key_map={"user_id": "id123"})
-        self.assertEquals(resp.result.features, [])
+        self.assertEqual(resp.result.features, [])
 
     def test_raise_error(self):
         test_client = httpx.Client(


### PR DESCRIPTION
Calling `AsyncTectonClient.get_feature_service_metadata()` currently produces the following error when used:

```
AttributeError: 'coroutine' object has no attribute 'raise_for_status'
sys:1: RuntimeWarning: coroutine 'AsyncClient.post' was never awaited
```

Also the async unittests weren't running :(. The pytest.mark decorator I was using doesn't work on unittest TestCase class; instead updating to use `unittest.IsolatedAsyncioTestCase`

Also updated to use `AssertEqual` instead of `AssertEquals` to remove some warnings messages while running tests.