### PR TITLE
Add ULR validation and SLOInfo Object

### DIFF
--- a/examples/example_sync.py
+++ b/examples/example_sync.py
@@ -12,7 +12,7 @@ resp = client.get_features(
     feature_service_name="fraud_detection_feature_service:v2",
     join_key_map={"user_id": "user_4407104885"},
     request_context_map={"amount": 500.00},
-    metadata_options=MetadataOptions(include_data_types=True),
+    metadata_options=MetadataOptions(include_all=True),
 )
 
 print("A nicely formatted output")

--- a/tecton_client/__init__.py
+++ b/tecton_client/__init__.py
@@ -1,9 +1,8 @@
 from tecton_client._internal.async_tecton_client import AsyncTectonClient
-from tecton_client._internal.data_types import (
+from tecton_client._internal.request_utils import MetadataOptions, RequestOptions
+from tecton_client._internal.response_utils import (
     GetFeatureServiceMetadataResponse,
     GetFeaturesResponse,
-    MetadataOptions,
-    RequestOptions,
 )
 from tecton_client._internal.tecton_client import TectonClient
 

--- a/tecton_client/__init__.py
+++ b/tecton_client/__init__.py
@@ -3,6 +3,7 @@ from tecton_client._internal.request_utils import MetadataOptions, RequestOption
 from tecton_client._internal.response_utils import (
     GetFeatureServiceMetadataResponse,
     GetFeaturesResponse,
+    SLOInfo,
 )
 from tecton_client._internal.tecton_client import TectonClient
 
@@ -13,4 +14,5 @@ __all__ = [
     "GetFeatureServiceMetadataResponse",
     "MetadataOptions",
     "RequestOptions",
+    "SLOInfo",
 ]

--- a/tecton_client/_internal/async_tecton_client.py
+++ b/tecton_client/_internal/async_tecton_client.py
@@ -4,11 +4,10 @@ from urllib.parse import urljoin
 import httpx
 from httpx import HTTPStatusError
 
-from tecton_client._internal.data_types import (
+from tecton_client._internal.request_utils import MetadataOptions, RequestOptions
+from tecton_client._internal.response_utils import (
     GetFeatureServiceMetadataResponse,
     GetFeaturesResponse,
-    MetadataOptions,
-    RequestOptions,
 )
 from tecton_client._internal.utils import (
     build_get_feature_service_metadata_request,

--- a/tecton_client/_internal/async_tecton_client.py
+++ b/tecton_client/_internal/async_tecton_client.py
@@ -15,6 +15,7 @@ from tecton_client._internal.utils import (
     build_get_features_request,
     get_default_headers,
     validate_request_args,
+    validate_url,
 )
 from tecton_client.exceptions import convert_exception
 
@@ -30,6 +31,7 @@ class AsyncTectonClient:
     .. code-block:: python
 
         import asyncio
+        from tecton_client import AsyncTectonClient, MetadataOptions
 
         async_client = AsyncTectonClient(
             url="http://explore.tecton.ai", api_key="my_key", default_workspace_name="prod"
@@ -63,6 +65,7 @@ class AsyncTectonClient:
             client: An httpx.Client, allowing you to provide finer-grained customization on the request behavior,
                 such as default timeout or connection settings. See https://www.python-httpx.org/ for more info.
         """
+        validate_url(url)
         self.url = url
         self.default_workspace_name = default_workspace_name
         self._api_key = api_key

--- a/tecton_client/_internal/data_types.py
+++ b/tecton_client/_internal/data_types.py
@@ -123,6 +123,7 @@ class MetadataOptions:
         include_effective_times: bool = False,
         include_slo_info: bool = False,
         include_serving_status: bool = False,
+        include_all: bool = False,
     ):
         """
         Args:
@@ -131,13 +132,21 @@ class MetadataOptions:
             include_effective_times: Include the effective times of the feature values in the response.
             include_slo_info: Include the SLO information as well as the Batch SLO Information in the response.
             include_serving_status: Include feature statuses in the response.
+            include_all: Include all metadata options
 
         """
-        self.include_names = include_names
-        self.include_data_types = include_data_types
-        self.include_effective_times = include_effective_times
-        self.include_slo_info = include_slo_info
-        self.include_serving_status = include_serving_status
+        if include_all:
+            self.include_names = True
+            self.include_data_types = True
+            self.include_effective_times = True
+            self.include_slo_info = True
+            self.include_serving_status = True
+        else:
+            self.include_names = include_names
+            self.include_data_types = include_data_types
+            self.include_effective_times = include_effective_times
+            self.include_slo_info = include_slo_info
+            self.include_serving_status = include_serving_status
 
     def to_request(self) -> Dict[str, bool]:
         """Format for inclusion in GetFeaturesRequest"""

--- a/tecton_client/_internal/request_utils.py
+++ b/tecton_client/_internal/request_utils.py
@@ -1,0 +1,68 @@
+from typing import Dict
+
+
+class MetadataOptions:
+    """Passed into metadata_options on get_features, controls what metadata is returned as part of the response."""
+
+    def __init__(
+        self,
+        include_names: bool = True,
+        include_data_types: bool = True,
+        include_effective_times: bool = False,
+        include_slo_info: bool = False,
+        include_serving_status: bool = False,
+        include_all: bool = False,
+    ):
+        """
+        Args:
+            include_names: Include the name of each feature in the response
+            include_data_types: Include the data type of each feature in the response
+            include_effective_times: Include the effective times of the feature values in the response.
+            include_slo_info: Include the SLO information as well as the Batch SLO Information in the response.
+            include_serving_status: Include feature statuses in the response.
+            include_all: Include all metadata options
+
+        """
+        if include_all:
+            self.include_names = True
+            self.include_data_types = True
+            self.include_effective_times = True
+            self.include_slo_info = True
+            self.include_serving_status = True
+        else:
+            self.include_names = include_names
+            self.include_data_types = include_data_types
+            self.include_effective_times = include_effective_times
+            self.include_slo_info = include_slo_info
+            self.include_serving_status = include_serving_status
+
+    def to_request(self) -> Dict[str, bool]:
+        """Format for inclusion in GetFeaturesRequest"""
+        return {
+            "includeNames": self.include_names,
+            "includeDataTypes": self.include_data_types,
+            "includeEffectiveTimes": self.include_effective_times,
+            "includeSloInfo": self.include_slo_info,
+            "includeServingStatus": self.include_serving_status,
+        }
+
+
+class RequestOptions:
+    """Passed into request_options on get_features, request level options to control feature server behavior."""
+
+    def __init__(self, read_from_cache: bool = True, write_to_cache: bool = True):
+        """this
+
+        Args:
+            read_from_cache: Disable if you want to skip the cache and read from the online store. Defaults to True.
+            write_to_cache: Disable if you want to skip writing to the cache. Defaults to True.
+        """
+        self.read_from_cache = read_from_cache
+        self.write_to_cache = write_to_cache
+
+    def to_request(self) -> Dict[str, bool]:
+        """Format for inclusion in GetFeaturesRequest"""
+        return {
+            "readFromCache": self.read_from_cache,
+            "writeToCache": self.write_to_cache,
+        }

--- a/tecton_client/_internal/response_utils.py
+++ b/tecton_client/_internal/response_utils.py
@@ -20,6 +20,16 @@ class GetFeaturesResult:
 
 
 @dataclass
+class SLOInfo:
+    slo_eligible: bool
+    slo_server_time_seconds: float
+    dynamodb_response_size_bytes: int
+    server_time_seconds: float
+    store_max_latency: float
+    store_response_size_bytes: int
+
+
+@dataclass
 class GetFeaturesResponse:
     """Response from get_feature_service_metadata.
 
@@ -31,7 +41,8 @@ class GetFeaturesResponse:
     """
 
     result: GetFeaturesResult
-    metadata: Optional[Dict] = None
+    metadata: Optional[Dict]
+    slo_info: Optional[SLOInfo]
 
     def get_features_dict(self) -> Dict[str, FeatureType]:
         """Return the feature values as a dictionary mapping name to value, and converting str to int64 if needed"""
@@ -84,7 +95,21 @@ class GetFeaturesResponse:
     @classmethod
     def from_response(cls, resp: dict) -> "GetFeaturesResponse":
         """Internal method for converting response of Service into an object"""
-        return GetFeaturesResponse(result=GetFeaturesResult(**resp["result"]), metadata=resp.get("metadata"))
+        raw_slo_info = resp.get("metadata", {}).get("sloInfo")
+        if resp.get("metadata", {}).get("sloInfo") is not None:
+            slo_info = SLOInfo(
+                slo_eligible=raw_slo_info.get("sloEligible"),
+                slo_server_time_seconds=raw_slo_info.get("sloServerTimeSeconds"),
+                dynamodb_response_size_bytes=raw_slo_info.get("dynamodbResponseSizeBytes"),
+                server_time_seconds=raw_slo_info.get("serverTimeSeconds"),
+                store_max_latency=raw_slo_info.get("storeMaxLatency"),
+                store_response_size_bytes=raw_slo_info.get("storeResponseSizeBytes"),
+            )
+        else:
+            slo_info = None
+        return GetFeaturesResponse(
+            result=GetFeaturesResult(**resp["result"]), metadata=resp.get("metadata"), slo_info=slo_info
+        )
 
 
 @dataclass
@@ -111,70 +136,3 @@ class GetFeatureServiceMetadataResponse:
             input_request_context_keys=resp.get("inputRequestContextKeys"),
             feature_values=resp["featureValues"],
         )
-
-
-class MetadataOptions:
-    """Passed into metadata_options on get_features, controls what metadata is returned as part of the response."""
-
-    def __init__(
-        self,
-        include_names: bool = True,
-        include_data_types: bool = True,
-        include_effective_times: bool = False,
-        include_slo_info: bool = False,
-        include_serving_status: bool = False,
-        include_all: bool = False,
-    ):
-        """
-        Args:
-            include_names: Include the name of each feature in the response
-            include_data_types: Include the data type of each feature in the response
-            include_effective_times: Include the effective times of the feature values in the response.
-            include_slo_info: Include the SLO information as well as the Batch SLO Information in the response.
-            include_serving_status: Include feature statuses in the response.
-            include_all: Include all metadata options
-
-        """
-        if include_all:
-            self.include_names = True
-            self.include_data_types = True
-            self.include_effective_times = True
-            self.include_slo_info = True
-            self.include_serving_status = True
-        else:
-            self.include_names = include_names
-            self.include_data_types = include_data_types
-            self.include_effective_times = include_effective_times
-            self.include_slo_info = include_slo_info
-            self.include_serving_status = include_serving_status
-
-    def to_request(self) -> Dict[str, bool]:
-        """Format for inclusion in GetFeaturesRequest"""
-        return {
-            "includeNames": self.include_names,
-            "includeDataTypes": self.include_data_types,
-            "includeEffectiveTimes": self.include_effective_times,
-            "includeSloInfo": self.include_slo_info,
-            "includeServingStatus": self.include_serving_status,
-        }
-
-
-class RequestOptions:
-    """Passed into request_options on get_features, request level options to control feature server behavior."""
-
-    def __init__(self, read_from_cache: bool = True, write_to_cache: bool = True):
-        """this
-
-        Args:
-            read_from_cache: Disable if you want to skip the cache and read from the online store. Defaults to True.
-            write_to_cache: Disable if you want to skip writing to the cache. Defaults to True.
-        """
-        self.read_from_cache = read_from_cache
-        self.write_to_cache = write_to_cache
-
-    def to_request(self) -> Dict[str, bool]:
-        """Format for inclusion in GetFeaturesRequest"""
-        return {
-            "readFromCache": self.read_from_cache,
-            "writeToCache": self.write_to_cache,
-        }

--- a/tecton_client/_internal/response_utils.py
+++ b/tecton_client/_internal/response_utils.py
@@ -21,9 +21,23 @@ class GetFeaturesResult:
 
 @dataclass
 class SLOInfo:
+    """SLO and Serving time information. This is useful for debugging latency. Note: This will only be
+            included if MetadataOption.include_slo_info is set to True in get_features(), otherwise it will be None.
+
+    Attributes:
+        slo_eligible: Whether the request was eligible for the latency SLO.
+        slo_ineligibility_reasons: If slo_eligible is False, indicates the reason why.
+        slo_server_time_seconds: The latency, in seconds of this request. This is the value that will be used for the
+            latency SLI.
+        server_time_seconds: The latency, in seconds, of this request as measured by the server. This includes the
+            total time spent in the feature server including online transforms and store latency.
+        store_max_latency: The maximum latency observed by the request from the online store in seconds.
+        store_response_size_bytes: Total online store response size in bytes.
+    """
+
     slo_eligible: bool
+    slo_ineligibility_reasons: Optional[List[str]]
     slo_server_time_seconds: float
-    dynamodb_response_size_bytes: int
     server_time_seconds: float
     store_max_latency: float
     store_response_size_bytes: int
@@ -101,8 +115,8 @@ class GetFeaturesResponse:
         if resp.get("metadata", {}).get("sloInfo") is not None:
             slo_info = SLOInfo(
                 slo_eligible=raw_slo_info.get("sloEligible"),
+                slo_ineligibility_reasons=raw_slo_info.get("sloIneligibilityReasons"),
                 slo_server_time_seconds=raw_slo_info.get("sloServerTimeSeconds"),
-                dynamodb_response_size_bytes=raw_slo_info.get("dynamodbResponseSizeBytes"),
                 server_time_seconds=raw_slo_info.get("serverTimeSeconds"),
                 store_max_latency=raw_slo_info.get("storeMaxLatency"),
                 store_response_size_bytes=raw_slo_info.get("storeResponseSizeBytes"),

--- a/tecton_client/_internal/response_utils.py
+++ b/tecton_client/_internal/response_utils.py
@@ -38,6 +38,8 @@ class GetFeaturesResponse:
             For a mapping of feature names to values, use get_features_dict()
         metadata: Any metadata returned. Control what metadata is returned from service using `metadata_options`
             parameter of `get_features`.
+        slo_info: SLO and Serving time information. This is useful for debugging latency. Note: This will only be
+            included if MetadataOption.include_slo_info is set to True in get_features(), otherwise it will be None.
     """
 
     result: GetFeaturesResult

--- a/tecton_client/_internal/tecton_client.py
+++ b/tecton_client/_internal/tecton_client.py
@@ -4,11 +4,10 @@ from urllib.parse import urljoin
 import httpx
 from httpx import HTTPStatusError
 
-from tecton_client._internal.data_types import (
+from tecton_client._internal.request_utils import MetadataOptions, RequestOptions
+from tecton_client._internal.response_utils import (
     GetFeatureServiceMetadataResponse,
     GetFeaturesResponse,
-    MetadataOptions,
-    RequestOptions,
 )
 from tecton_client._internal.utils import (
     build_get_feature_service_metadata_request,

--- a/tecton_client/_internal/tecton_client.py
+++ b/tecton_client/_internal/tecton_client.py
@@ -15,6 +15,7 @@ from tecton_client._internal.utils import (
     build_get_features_request,
     get_default_headers,
     validate_request_args,
+    validate_url,
 )
 from tecton_client.exceptions import convert_exception
 
@@ -28,6 +29,7 @@ class TectonClient:
     Examples:
 
     .. code-block:: python
+        from tecton_client import TectonClient, MetadataOptions
 
         client = TectonClient(
             url="http://explore.tecton.ai", api_key="my_key", default_workspace_name="prod"
@@ -55,6 +57,7 @@ class TectonClient:
             client: An httpx.Client, allowing you to provide finer-grained customization on the request behavior,
                 such as default timeout or connection settings. See https://www.python-httpx.org/ for more info.
         """
+        validate_url(url)
         self.url = url
         self.default_workspace_name = default_workspace_name
         self._api_key = api_key

--- a/tecton_client/_internal/utils.py
+++ b/tecton_client/_internal/utils.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 import httpx
 
 from tecton_client.__about__ import __version__ as tecton_client_version
-from tecton_client._internal.data_types import MetadataOptions, RequestOptions
+from tecton_client._internal.request_utils import MetadataOptions, RequestOptions
 
 
 def get_default_headers(api_key):

--- a/tecton_client/_internal/utils.py
+++ b/tecton_client/_internal/utils.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional, Union
+from urllib.parse import urlparse
 
 import httpx
 
@@ -66,3 +67,9 @@ def validate_request_args(
     if not feature_service_name:
         msg = "feature_service_name must be provided"
         raise ValueError(msg)
+
+
+def validate_url(url: str):
+    parse_result = urlparse(url)
+    if parse_result.scheme not in ("http", "https"):
+        raise ValueError("Invalid URL: Must begin with http:// or https://")

--- a/tecton_client/_internal/utils.py
+++ b/tecton_client/_internal/utils.py
@@ -3,13 +3,13 @@ from urllib.parse import urlparse
 
 import httpx
 
-from tecton_client.__about__ import __version__ as tecton_version
+from tecton_client.__about__ import __version__ as tecton_client_version
 from tecton_client._internal.data_types import MetadataOptions, RequestOptions
 
 
 def get_default_headers(api_key):
     return httpx.Headers(
-        {"Authorization": "Tecton-key " + api_key, "User-Agent": "tecton-http-python-client " + tecton_version}
+        {"Authorization": "Tecton-key " + api_key, "User-Agent": "tecton-http-python-client " + tecton_client_version}
     )
 
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -25,7 +25,7 @@ class TestTectonClient(IsolatedAsyncioTestCase):
         self.mock_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         self.mock_client._request_log = _request_log
 
-    @patch("tecton_client._internal.utils.tecton_version", "0.1.0test")
+    @patch("tecton_client._internal.utils.tecton_client_version", "0.1.0test")
     def test_client_construction(self):
         mock_httpx_constructor = self.mockPatch("httpx.AsyncClient", autospec=True)
         AsyncTectonClient(url="https://fake.tecton.ai", api_key="fake-api-key", default_workspace_name="workspace")
@@ -35,7 +35,7 @@ class TestTectonClient(IsolatedAsyncioTestCase):
             )
         )
 
-    @patch("tecton_client._internal.utils.tecton_version", "0.1.0test")
+    @patch("tecton_client._internal.utils.tecton_client_version", "0.1.0test")
     def test_client_construction_custom_client(self):
         mock_httpx_constructor = self.mockPatch("httpx.AsyncClient", autospec=True)
         mock_client = MagicMock()

--- a/tests/test_data/slo_info_sample_response.json
+++ b/tests/test_data/slo_info_sample_response.json
@@ -1,0 +1,58 @@
+{
+  "result": {
+    "features": [
+      ["0"],
+      null,
+      [55.5, 57.88, 58.96, 57.66, null, 55.98],
+      ["0", "1", null, "3", "4", null]
+    ]
+  },
+  "metadata": {
+    "features": [
+      {
+        "name":"average_rain.rain_in_last_24_hrs",
+        "dataType": {
+          "type": "array",
+          "elementType": {
+            "type": "int64"
+          }
+        }
+      },
+      {
+        "name":"average_rain.cloud_type",
+        "dataType": {
+          "type": "array",
+          "elementType": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name":"average_rain.average_temperate_6hrs",
+        "dataType": {
+          "type": "array",
+          "elementType": {
+            "type": "float64"
+          }
+        }
+      },
+      {
+        "name":"average_rain.fake_example",
+        "dataType": {
+          "type": "array",
+          "elementType": {
+            "type": "int64"
+          }
+        }
+      }
+    ],
+    "sloInfo": {
+      "sloEligible": true,
+      "sloServerTimeSeconds": 0.01,
+      "dynamodbResponseSizeBytes": 2048,
+      "serverTimeSeconds": 0.02,
+      "storeMaxLatency": 0.03,
+      "storeResponseSizeBytes": 4096
+    }
+  }
+}

--- a/tests/test_response_utils.py
+++ b/tests/test_response_utils.py
@@ -92,8 +92,8 @@ class TestResponses(TestCase):
             resp.slo_info,
             SLOInfo(
                 slo_eligible=True,
+                slo_ineligibility_reasons=None,
                 slo_server_time_seconds=0.01,
-                dynamodb_response_size_bytes=2048,
                 server_time_seconds=0.02,
                 store_max_latency=0.03,
                 store_response_size_bytes=4096,

--- a/tests/test_response_utils.py
+++ b/tests/test_response_utils.py
@@ -3,11 +3,12 @@ import pathlib
 from unittest import TestCase
 
 from tecton_client import GetFeaturesResponse
+from tecton_client._internal.response_utils import SLOInfo
 
 TEST_DATA_DIR = pathlib.Path(__file__).parent.joinpath("test_data")
 
 
-class TestDataTypes(TestCase):
+class TestResponses(TestCase):
     def test_GetFeaturesResponse_from_dict(self):
         self.maxDiff = 10000
         file_1 = TEST_DATA_DIR.joinpath("sample_response.json")
@@ -75,6 +76,32 @@ class TestDataTypes(TestCase):
             },
         )
 
+    def test_GetFeaturesResponse_slo_info_null(self):
+        file_1 = TEST_DATA_DIR.joinpath("sample_response.json")
+        with open(file_1) as f:
+            resp = json.load(f)
+        resp = GetFeaturesResponse.from_response(resp)
+        self.assertIsNone(resp.slo_info)
+
+    def test_GetFeaturesResponse_slo_info(self):
+        file_1 = TEST_DATA_DIR.joinpath("slo_info_sample_response.json")
+        with open(file_1) as f:
+            resp = json.load(f)
+        resp = GetFeaturesResponse.from_response(resp)
+        self.assertEqual(
+            resp.slo_info,
+            SLOInfo(
+                slo_eligible=True,
+                slo_server_time_seconds=0.01,
+                dynamodb_response_size_bytes=2048,
+                server_time_seconds=0.02,
+                store_max_latency=0.03,
+                store_response_size_bytes=4096,
+            ),
+        )
+
+
+class TestGetFeatureValue(TestCase):
     def test_get_feature_value_simple_types(self):
         self.assertEqual(GetFeaturesResponse._get_feature_value({"type": "string"}, "thing"), "thing")
         self.assertEqual(GetFeaturesResponse._get_feature_value({"type": "string"}, "thing"), "thing")

--- a/tests/test_tecton_client.py
+++ b/tests/test_tecton_client.py
@@ -129,6 +129,43 @@ class TestTectonClient(TestCase):
             },
         )
 
+    def test_get_features_metadata_all(self):
+        # using just magic_mock here in order to assert on client.post.assert_called_with
+        mock_http_client = MagicMock()
+        mock_http_client.post.return_value.json.return_value = {"result": {"features": []}}
+        client = TectonClient(
+            url="https://fake.tecton.ai",
+            api_key="fake-api-key",
+            default_workspace_name="workspace",
+            client=mock_http_client,
+        )
+        client.get_features(
+            feature_service_name="fake-feature-service",
+            join_key_map={"user_id": "id123"},
+            metadata_options=MetadataOptions(include_all=True),
+            request_options=RequestOptions(read_from_cache=False),
+        )
+        mock_http_client.post.assert_called_with(
+            "https://fake.tecton.ai/api/v1/feature-service/get-features",
+            json={
+                "params": {
+                    "workspaceName": "workspace",
+                    "featureServiceName": "fake-feature-service",
+                    "joinKeyMap": {"user_id": "id123"},
+                    "requestContextMap": {},
+                    "allowPartialResults": False,
+                    "metadataOptions": {
+                        "includeNames": True,
+                        "includeDataTypes": True,
+                        "includeEffectiveTimes": True,
+                        "includeSloInfo": True,
+                        "includeServingStatus": True,
+                    },
+                    "requestOptions": {"readFromCache": False, "writeToCache": True},
+                }
+            },
+        )
+
     def test_get_feature_service_metadata_encode(self):
         # using just magic_mock here in order to assert on client.post.assert_called_with
         mock_http_client = MagicMock()

--- a/tests/test_tecton_client.py
+++ b/tests/test_tecton_client.py
@@ -25,7 +25,7 @@ class TestTectonClient(TestCase):
         self.mock_client = httpx.Client(transport=httpx.MockTransport(handler))
         self.mock_client._request_log = _request_log
 
-    @patch("tecton_client._internal.utils.tecton_version", "0.1.0test")
+    @patch("tecton_client._internal.utils.tecton_client_version", "0.1.0test")
     def test_client_construction(self):
         mock_httpx_constructor = self.mockPatch("httpx.Client", autospec=True)
         TectonClient(url="https://fake.tecton.ai", api_key="fake-api-key", default_workspace_name="workspace")
@@ -35,7 +35,12 @@ class TestTectonClient(TestCase):
             )
         )
 
-    @patch("tecton_client._internal.utils.tecton_version", "0.1.0test")
+    @patch("tecton_client._internal.utils.tecton_client_version", "0.1.0test")
+    def test_client_constructio_bad_url(self):
+        with self.assertRaises(ValueError):
+            TectonClient(url="fake.tecton.ai", api_key="fake-api-key", default_workspace_name="workspace")
+
+    @patch("tecton_client._internal.utils.tecton_client_version", "0.1.0test")
     def test_client_construction_custom_client(self):
         mock_httpx_constructor = self.mockPatch("httpx.Client", autospec=True)
         mock_client = MagicMock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+from tecton_client._internal.utils import validate_url
+
+
+class TestValidation(TestCase):
+    def test_validate_url(self):
+        validate_url("https://explore.tecton.ai")
+        validate_url("http://explore.tecton.ai")
+        validate_url("http://127.0.0.1")
+        with self.assertRaisesRegexp(ValueError, "Invalid URL: Must begin with"):
+            validate_url("explore.tecton.ai")
+
+        with self.assertRaisesRegexp(ValueError, "Invalid URL: Must begin with"):
+            validate_url("https.explore.tecton.ai")
+
+        with self.assertRaisesRegexp(ValueError, "Invalid URL: Must begin with"):
+            validate_url("ftp://explore.tecton.ai")


### PR DESCRIPTION
1. Add SLOInfo as a top-level object on GetFeaturesResponse
2. Add URL Validation to give early feedback if someone omitted the `http://` in a url
3. Broke `data_types` into `request_utils` and `response_utils`. Not totally necessary.