### PR TITLE
Update gh-action-pypi-publish version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         path: ./dist
 
     - name: Push build artifacts to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1.12.4
 
   add-to-github-release:
     name: sign the artifacts and add them to the github release


### PR DESCRIPTION
Fixing issue with pypi publish: https://github.com/tecton-ai/tecton-http-client-python/actions/runs/16487227290/job/46614242053